### PR TITLE
fix(compareArray): fix adding duplicate items to arrays not generating add operation

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -233,21 +233,18 @@ func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 // processArray processes `av` and `bv` calling `applyOp` whenever a value is absent.
 // It keeps track of which indexes have already had `applyOp` called for and automatically skips them so you can process duplicate objects correctly.
 func processArray(av, bv []interface{}, applyOp func(i int, value interface{})) {
-	foundIndexes := make(map[int]int, len(av))
+	foundIndexes := make(map[int]struct{}, len(av))
+	reverseFoundIndexes := make(map[int]struct{}, len(av))
 	for i, v := range av {
 		for i2, v2 := range bv {
-			alreadyFoundThisIndex := true
-			for _, foundI2 := range foundIndexes {
-				if foundI2 == i2 {
-					alreadyFoundThisIndex = false
-					break
-				}
-			}
-			if !alreadyFoundThisIndex {
+			if _, ok := reverseFoundIndexes[i2]; ok {
+				// We already found this index.
 				continue
 			}
 			if reflect.DeepEqual(v, v2) {
-				foundIndexes[i] = i2
+				// Mark this index as found since it matches exactly.
+				foundIndexes[i] = struct{}{}
+				reverseFoundIndexes[i2] = struct{}{}
 				break
 			}
 		}

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -26,12 +26,17 @@ func TestArrayAddMultipleEmptyObjects(t *testing.T) {
 	assert.Equal(t, "add", change.Operation, "they should be equal")
 	assert.Equal(t, "/persons/2", change.Path, "they should be equal")
 	assert.Equal(t, map[string]interface{}{}, change.Value, "they should be equal")
-	// change = patch[1]
-	// assert.Equal(t, "add", change.Operation, "they should be equal")
-	// assert.Equal(t, "/goods/2/batters/batter/2", change.Path, "they should be equal")
-	// assert.Equal(t, map[string]interface{}{"id": "1003", "type": "Vanilla"}, change.Value, "they should be equal")
-	// change = patch[2]
-	// assert.Equal(t, change.Operation, "remove", "they should be equal")
-	// assert.Equal(t, change.Path, "/goods/2/topping/2", "they should be equal")
-	// assert.Equal(t, nil, change.Value, "they should be equal")
+}
+
+func TestArrayRemoveMultipleEmptyObjects(t *testing.T) {
+	patch, e := CreatePatch([]byte(arrayUpdated), []byte(arrayBase))
+	assert.NoError(t, e)
+	t.Log("Patch:", patch)
+	assert.Equal(t, 1, len(patch), "they should be equal")
+	sort.Sort(ByPath(patch))
+
+	change := patch[0]
+	assert.Equal(t, "remove", change.Operation, "they should be equal")
+	assert.Equal(t, "/persons/2", change.Path, "they should be equal")
+	assert.Equal(t, nil, change.Value, "they should be equal")
 }

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -1,0 +1,37 @@
+package jsonpatch
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var arrayBase = `{
+  "persons": [{"name":"Ed"},{}]
+}`
+
+var arrayUpdated = `{
+  "persons": [{"name":"Ed"},{},{}]
+}`
+
+func TestArrayAddMultipleEmptyObjects(t *testing.T) {
+	patch, e := CreatePatch([]byte(arrayBase), []byte(arrayUpdated))
+	assert.NoError(t, e)
+	t.Log("Patch:", patch)
+	assert.Equal(t, 1, len(patch), "they should be equal")
+	sort.Sort(ByPath(patch))
+
+	change := patch[0]
+	assert.Equal(t, "add", change.Operation, "they should be equal")
+	assert.Equal(t, "/persons/2", change.Path, "they should be equal")
+	assert.Equal(t, map[string]interface{}{}, change.Value, "they should be equal")
+	// change = patch[1]
+	// assert.Equal(t, "add", change.Operation, "they should be equal")
+	// assert.Equal(t, "/goods/2/batters/batter/2", change.Path, "they should be equal")
+	// assert.Equal(t, map[string]interface{}{"id": "1003", "type": "Vanilla"}, change.Value, "they should be equal")
+	// change = patch[2]
+	// assert.Equal(t, change.Operation, "remove", "they should be equal")
+	// assert.Equal(t, change.Path, "/goods/2/topping/2", "they should be equal")
+	// assert.Equal(t, nil, change.Value, "they should be equal")
+}

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var arrayBase = `{
+var (
+	arrayBase = `{
   "persons": [{"name":"Ed"},{}]
 }`
 
-var arrayUpdated = `{
+	arrayUpdated = `{
   "persons": [{"name":"Ed"},{},{}]
 }`
+)
 
 func TestArrayAddMultipleEmptyObjects(t *testing.T) {
 	patch, e := CreatePatch([]byte(arrayBase), []byte(arrayUpdated))
@@ -30,6 +32,31 @@ func TestArrayAddMultipleEmptyObjects(t *testing.T) {
 
 func TestArrayRemoveMultipleEmptyObjects(t *testing.T) {
 	patch, e := CreatePatch([]byte(arrayUpdated), []byte(arrayBase))
+	assert.NoError(t, e)
+	t.Log("Patch:", patch)
+	assert.Equal(t, 1, len(patch), "they should be equal")
+	sort.Sort(ByPath(patch))
+
+	change := patch[0]
+	assert.Equal(t, "remove", change.Operation, "they should be equal")
+	assert.Equal(t, "/persons/2", change.Path, "they should be equal")
+	assert.Equal(t, nil, change.Value, "they should be equal")
+}
+
+var (
+	arrayWithSpacesBase = `{
+	"persons": [{"name":"Ed"},{},{},{"name":"Sally"},{}]
+}`
+
+	arrayWithSpacesUpdated = `{
+  "persons": [{"name":"Ed"},{},{"name":"Sally"},{}]
+}`
+)
+
+// TestArrayRemoveSpaceInbetween tests removing one blank item from a group blanks which is in between non blank items which also end with a blank item. This tests that the correct index is removed
+func TestArrayRemoveSpaceInbetween(t *testing.T) {
+	t.Skip("This test fails. TODO change compareArray algorithm to match by index instead of by object equality")
+	patch, e := CreatePatch([]byte(arrayWithSpacesBase), []byte(arrayWithSpacesUpdated))
 	assert.NoError(t, e)
 	t.Log("Patch:", patch)
 	assert.Equal(t, 1, len(patch), "they should be equal")


### PR DESCRIPTION
If you added duplicate items to an array `compareArray` would not generate an add operation because it previously just checked that the object was in the array. Objects are now marked(via a map) that they have already been used and should be skipped. This fixes `compareArray` so that it can detect and generate proper patches when adding duplicate objects.

See `jsonpatch_array_test.go` for an example of when this happens.

```
PASS
coverage: 77.0% of statements
ok github.com/mattbaird/jsonpatch	0.042s
```