### PR TITLE
make array comparison faster

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -220,6 +220,7 @@ func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 		for _, v2 := range bv {
 			if reflect.DeepEqual(v, v2) {
 				found = true
+				break
 			}
 		}
 		if !found {
@@ -232,6 +233,7 @@ func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 		for _, v2 := range av {
 			if reflect.DeepEqual(v, v2) {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/jsonpatch_simple_test.go
+++ b/jsonpatch_simple_test.go
@@ -1,9 +1,10 @@
 package jsonpatch
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var simpleA = `{"a":100, "b":200, "c":"hello"}`
@@ -88,4 +89,32 @@ func TestVsEmpty(t *testing.T) {
 	change = patch[2]
 	assert.Equal(t, change.Operation, "remove", "they should be equal")
 	assert.Equal(t, change.Path, "/c", "they should be equal")
+}
+
+func BenchmarkBigArrays(b *testing.B) {
+	var a1, a2 []interface{}
+	a1 = make([]interface{}, 100)
+	a2 = make([]interface{}, 101)
+
+	for i := 0; i < 100; i++ {
+		a1[i] = i
+		a2[i+1] = i
+	}
+	for i := 0; i < b.N; i++ {
+		compareArray(a1, a2, "/")
+	}
+}
+
+func BenchmarkBigArrays2(b *testing.B) {
+	var a1, a2 []interface{}
+	a1 = make([]interface{}, 100)
+	a2 = make([]interface{}, 101)
+
+	for i := 0; i < 100; i++ {
+		a1[i] = i
+		a2[i] = i
+	}
+	for i := 0; i < b.N; i++ {
+		compareArray(a1, a2, "/")
+	}
 }


### PR DESCRIPTION
get rid of redundant comparisons

in array comparison, if match has been found - no need to proceed
further - break at that point and proceed with next element

```
go test -bench .
BenchmarkBigArrays-8    	    1000	   1811571 ns/op
BenchmarkBigArrays2-8   	    1000	   1822322 ns/op
PASS
ok  	github.com/edast/jsonpatch	4.010s
```

after adding break statements:
```
go test -bench .
BenchmarkBigArrays-8    	    2000	    911185 ns/op
BenchmarkBigArrays2-8   	    2000	    923130 ns/op
PASS
ok  	github.com/edast/jsonpatch	3.877s
```