### PR TITLE
encode keys (support rfc6901#section-4)

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -125,17 +125,26 @@ func matchesValue(av, bv interface{}) bool {
 	return false
 }
 
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+//   TODO decode support:
+//   var rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+
+var rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
+
 func makePath(path string, newPart interface{}) string {
+	key := rfc6901Encoder.Replace(fmt.Sprintf("%v", newPart))
 	if path == "" {
-		return fmt.Sprintf("/%v", newPart)
-	} else {
-		if strings.HasSuffix(path, "/") {
-			path = path + fmt.Sprintf("%v", newPart)
-		} else {
-			path = path + fmt.Sprintf("/%v", newPart)
-		}
+		return "/" + key
 	}
-	return path
+	if strings.HasSuffix(path, "/") {
+		return path + key
+	}
+	return path + "/" + key
 }
 
 // diff returns the (recursive) difference between a and b as an array of JsonPatchOperations.


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc6901#section-4

This is supported by all the major patch decoders:
https://github.com/Starcounter-Jack/JSON-Patch
https://github.com/bruth/jsonpatch-js
https://github.com/dharmafly/jsonpatch.js