### PR TITLE
reverse array when remove multi groups from array

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -234,7 +234,11 @@ func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 	processArray(av, bv, func(i int, value interface{}) {
 		retval = append(retval, NewPatch("remove", makePath(p, i), nil))
 	})
-
+	reversed := make([]JsonPatchOperation, len(retval))
+	for i := 0; i < len(retval); i++ {
+		reversed[len(retval)-1-i] = retval[i]
+	}
+	retval = reversed
 	// Find elements that need to be added.
 	// NOTE we pass in `bv` then `av` so that processArray can find the missing elements.
 	processArray(bv, av, func(i int, value interface{}) {

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -67,3 +67,26 @@ func TestArrayRemoveSpaceInbetween(t *testing.T) {
 	assert.Equal(t, "/persons/2", change.Path, "they should be equal")
 	assert.Equal(t, nil, change.Value, "they should be equal")
 }
+
+var (
+	arrayRemoveMultiBase = `{
+	"persons": [{"name":"Ed"},{"name":"Ee"},{"name":"Ef"},{"name":"Sally"},{}]
+}`
+
+	arrayRemoveMultisUpdated = `{
+  "persons": [{"name":"Ef"},{},{"name":"Sally"},{}]
+}`
+)
+
+// TestArrayRemoveMulti tests removing multi groups. This tests that the correct index is removed
+func TestArrayRemoveMulti(t *testing.T) {
+	patch, e := CreatePatch([]byte(arrayRemoveMultiBase), []byte(arrayRemoveMultisUpdated))
+	assert.NoError(t, e)
+	t.Log("Patch:", patch)
+	assert.Equal(t, 3, len(patch), "they should be equal")
+
+	change := patch[0]
+	assert.Equal(t, "remove", change.Operation, "they should be equal")
+	assert.Equal(t, "/persons/1", change.Path, "they should be equal")
+	assert.Equal(t, nil, change.Value, "they should be equal")
+}


### PR DESCRIPTION
See this issue I opened in https://github.com/evanphx/json-patch/issues/106
and the PR https://github.com/evanphx/json-patch/pull/107


I used this library(CreatePatch) to crate a jsonPath for `K8s webhook`.  When the K8s internal logics apply the patch, we meet `invalid index`.

This PR reverses the order when when should remove multi items.

