### PR TITLE
Allow "null" value with operation "test"

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -27,7 +27,7 @@ func (j *JsonPatchOperation) MarshalJSON() ([]byte, error) {
 	b.WriteString(fmt.Sprintf(`"op":"%s"`, j.Operation))
 	b.WriteString(fmt.Sprintf(`,"path":"%s"`, j.Path))
 	// Consider omitting Value for non-nullable operations.
-	if j.Value != nil || j.Operation == "replace" || j.Operation == "add" {
+	if j.Value != nil || j.Operation == "replace" || j.Operation == "add" || j.Operation == "test" {
 		v, err := json.Marshal(j.Value)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
> [4.6](https://datatracker.ietf.org/doc/html/rfc6902/#section-4.6).  test
> ...
> The operation object MUST contain a "value" member that conveys the
   value to be compared to the target location's value.
> ...
>   literals (false, true, and null): are considered equal if they are
      the same.
> ...

According to RFC, the operation object `test` must contain a value, and `null` is a valid value. `MarshalJSON()` should not omit `null` if the operation is `test`.